### PR TITLE
`prepSCE`: only replace colData of original SCE

### DIFF
--- a/R/prepSCE.R
+++ b/R/prepSCE.R
@@ -69,17 +69,13 @@ prepSCE <- function(x,
         cd <- data.frame(cd,
             cd0[setdiff(colnames(cd0), ids)], 
             check.names = FALSE)
-        
-    # construct SCE
-    sce <- SingleCellExperiment(
-        assays = assays(x),
-        colData = DataFrame(cd),
-        rowData = rowData(x),
-        reducedDims = reducedDims(x))
-    
+
+    # replace colData in SCE
+    colData(x) <- DataFrame(cd)
+
     # construct metadata
-    ei <- .make_ei(sce)
-    metadata(sce)$experiment_info <- ei
+    ei <- .make_ei(x)
+    metadata(x)$experiment_info <- ei
     
-    return(sce)
+    return(x)
 }

--- a/R/prepSCE.R
+++ b/R/prepSCE.R
@@ -3,7 +3,7 @@
 #' 
 #' @description ...
 #' 
-#' @param x a \code{\link[SingleCellExperiment]{SingleCellExperiment}}.
+#' @param x a \linkS4class{SingleCellExperiment}.
 #' @param kid,sid,gid character strings specifying
 #'   the \code{colData(x)} columns containing cluster assignments,
 #'   unique sample identifiers, and group IDs (e.g., treatment).
@@ -16,28 +16,28 @@
 #' # generate random counts
 #' ng <- 50
 #' nc <- 200
-#' counts <- matrix(sample(ng * nc), nrow = ng, ncol = nc)
 #'     
 #' # generate some cell metadata
 #' gids <- sample(c("groupA", "groupB"), nc, TRUE)   
 #' sids <- sample(paste0("sample", seq_len(3)), nc, TRUE) 
 #' kids <- sample(paste0("cluster", seq_len(5)), nc, TRUE) 
 #' batch <- sample(seq_len(3), nc, TRUE)
+#' cd <- data.frame(group = gids, id = sids, cluster = kids, batch)
 #' 
 #' # construct SCE
-#' library(SingleCellExperiment)
-#' sce <- SingleCellExperiment(
-#'   assays = list(counts = counts),
-#'   colData = data.frame(group = gids, id = sids, cluster = kids, batch))
-#'     
+#' library(scuttle)
+#' sce <- mockSCE(ncells = nc, ngenes = ng)
+#' colData(sce) <- cbind(colData(sce), cd)
+#' 
 #' # prep. for workflow
 #' sce <- prepSCE(sce, kid = "cluster", sid = "id", gid = "group")
 #' head(colData(sce))
 #' metadata(sce)$experiment_info
+#' sce
 #' 
 #' @author Helena L Crowell
 #' 
-#' @return a \code{\link[SingleCellExperiment]{SingleCellExperiment}}.
+#' @return a \linkS4class{SingleCellExperiment}.
 #' 
 #' @importFrom dplyr mutate_all
 #' @importFrom S4Vectors DataFrame metadata<-

--- a/man/prepSCE.Rd
+++ b/man/prepSCE.Rd
@@ -13,7 +13,7 @@ prepSCE(
 )
 }
 \arguments{
-\item{x}{a \code{\link[SingleCellExperiment]{SingleCellExperiment}}.}
+\item{x}{a \linkS4class{SingleCellExperiment}.}
 
 \item{kid, sid, gid}{character strings specifying
 the \code{colData(x)} columns containing cluster assignments,
@@ -25,7 +25,7 @@ should be retained (default \code{drop = FALSE})
 or removed (\code{drop = TRUE}).}
 }
 \value{
-a \code{\link[SingleCellExperiment]{SingleCellExperiment}}.
+a \linkS4class{SingleCellExperiment}.
 }
 \description{
 ...
@@ -34,24 +34,24 @@ a \code{\link[SingleCellExperiment]{SingleCellExperiment}}.
 # generate random counts
 ng <- 50
 nc <- 200
-counts <- matrix(sample(ng * nc), nrow = ng, ncol = nc)
     
 # generate some cell metadata
 gids <- sample(c("groupA", "groupB"), nc, TRUE)   
 sids <- sample(paste0("sample", seq_len(3)), nc, TRUE) 
 kids <- sample(paste0("cluster", seq_len(5)), nc, TRUE) 
 batch <- sample(seq_len(3), nc, TRUE)
+cd <- data.frame(group = gids, id = sids, cluster = kids, batch)
 
 # construct SCE
-library(SingleCellExperiment)
-sce <- SingleCellExperiment(
-  assays = list(counts = counts),
-  colData = data.frame(group = gids, id = sids, cluster = kids, batch))
-    
+library(scuttle)
+sce <- mockSCE(ncells = nc, ngenes = ng)
+colData(sce) <- cbind(colData(sce), cd)
+
 # prep. for workflow
 sce <- prepSCE(sce, kid = "cluster", sid = "id", gid = "group")
 head(colData(sce))
 metadata(sce)$experiment_info
+sce
 
 }
 \author{

--- a/tests/testthat/test-prepSCE.R
+++ b/tests/testthat/test-prepSCE.R
@@ -21,4 +21,5 @@ test_that("prepSCE()", {
     expect_true(is.null(y$foo))
     y <- prepSCE(x, drop = FALSE)
     expect_identical(y$foo, x$foo)
+    expect_false(is.null(metadata(y)$experiment_info))
 })


### PR DESCRIPTION
Keep the original *SingleCellExperiment* object and only replace the `colData()` and add `experiment_info` to the `metadata()`. This ensures that other slots, such as `altExps()` or prior `metadata()` are retained.

Other minor additions:

- Added a check in `test-prepSCE` for the presence of `metadata()$experiment_info`
- Documentation of `prepSCE`: added link to *SingleCellExperiment* class documentation and now uses `scuttle::mockSCE()` in the example

The example using `scuttle::mockSCE()` shows the effect: the input `sce` contains an `altExp()`, which would have been removed before by `prepSCE()`. Now it remains:

``` r
library(muscat)

# generate random counts
ng <- 50
nc <- 200

# generate some cell metadata
gids <- sample(c("groupA", "groupB"), nc, TRUE)
sids <- sample(paste0("sample", seq_len(3)), nc, TRUE)
kids <- sample(paste0("cluster", seq_len(5)), nc, TRUE)
batch <- sample(seq_len(3), nc, TRUE)
cd <- data.frame(group = gids, id = sids, cluster = kids, batch)

# construct SCE
library(scuttle)
sce <- mockSCE(ncells = nc, ngenes = ng)
colData(sce) <- cbind(colData(sce), cd)

# prep. for workflow
sce <- prepSCE(sce, kid = "cluster", sid = "id", gid = "group")
sce
#> class: SingleCellExperiment 
#> dim: 50 200 
#> metadata(1): experiment_info
#> assays(1): counts
#> rownames(50): Gene_0001 Gene_0002 ... Gene_0049 Gene_0050
#> rowData names(0):
#> colnames(200): Cell_001 Cell_002 ... Cell_199 Cell_200
#> colData names(7): cluster_id sample_id ... Treatment batch
#> reducedDimNames(0):
#> mainExpName: NULL
#> altExpNames(1): Spikes
```