### PR TITLE
Adding lfcshrink and passing of downstream args to pbDS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: `muscat` provides various methods and visualization tools
     aggregated “pseudobulk” data, as well as a flexible simulation platform 
     that mimics both single and multi-sample scRNA-seq data.
 Type: Package
-Version: 1.27.1
+Version: 1.27.2
 Depends: R (>= 4.6)
 Authors@R: c(
 	person("Helena L.", "Crowell", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: `muscat` provides various methods and visualization tools
     aggregated “pseudobulk” data, as well as a flexible simulation platform 
     that mimics both single and multi-sample scRNA-seq data.
 Type: Package
-Version: 1.26.0
+Version: 1.27.0
 Depends: R (>= 4.6)
 Authors@R: c(
 	person("Helena L.", "Crowell", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: `muscat` provides various methods and visualization tools
     aggregated “pseudobulk” data, as well as a flexible simulation platform 
     that mimics both single and multi-sample scRNA-seq data.
 Type: Package
-Version: 1.27.0
+Version: 1.27.1
 Depends: R (>= 4.6)
 Authors@R: c(
 	person("Helena L.", "Crowell", 
@@ -58,7 +58,7 @@ biocViews: ImmunoOncology, DifferentialExpression, Sequencing,
     SingleCell, Software, StatisticalMethod, Visualization
 License: GPL-3
 VignetteBuilder: knitr
-RoxygenNote: 7.3.3
 Encoding: UTF-8
 URL: https://github.com/HelenaLC/muscat
 BugReports: https://github.com/HelenaLC/muscat/issues
+Config/roxygen2/version: 8.0.0

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+                        Changes in version 1.27.2
+
++ added logFC shrinkage option and downstream arguments to 'pbDS'
++ changed default edgeR normalization from TMM to TMMwsp
+
                         Changes in version 1.25.4
                         
 + update Gilis et al. citation for DD

--- a/R/mmDS.R
+++ b/R/mmDS.R
@@ -59,8 +59,8 @@
 #' @importFrom dplyr %>% mutate bind_rows
 #' @importFrom matrixStats rowMins
 #' @importFrom progress progress_bar
-#' @importFrom SingleCellExperiment counts counts<-
-#'   colData sizeFactors sizeFactors<-
+#' @importFrom SingleCellExperiment counts counts<- colData 
+#' @importFrom SingleCellExperiment sizeFactors sizeFactors<-
 #' @importFrom stats p.adjust
 #' @export
 

--- a/R/pbDS.R
+++ b/R/pbDS.R
@@ -8,7 +8,7 @@
 #' @param pb a \code{\link[SingleCellExperiment]{SingleCellExperiment}}
 #'   containing pseudobulks as returned by \code{\link{aggregateData}}.
 #' @param method a character string.
-#' @param design For methods \code{"edegR"} and \code{"limma"}, a design matrix 
+#' @param design For methods \code{"edgeR"} and \code{"limma"}, a design matrix 
 #'   with row & column names(!) created with \code{\link[stats]{model.matrix}}; 
 #'   For \code{"DESeq2"}, a formula with variables in \code{colData(pb)}.
 #'   Defaults to \code{~ group_id} or the corresponding \code{model.matrix}.
@@ -27,9 +27,17 @@
 #'   Only applicable for methods \code{"limma-x"} 
 #'   (\code{\link[limma:eBayes]{treat}}) and \code{"edgeR"} 
 #'   (\code{\link[edgeR]{glmTreat}}), and ignored otherwise.
+#' @param shrinkLFC Whether/how to shrink logFCs in DESeq2 analysis. Either 
+#'   FALSE (default, no shrinkage), TRUE (uses \code{\link[DESeq2]{lfcShrink}} 
+#'   with default method, which reguires the \code{apeglm} package), or a 
+#'   character argument indicating the shrinkage method, passed to 
+#'   \code{\link[DESeq2]{lfcShrink}}. Ignored for other methods.
 #' @param BPPARAM a \code{\link[BiocParallel]{BiocParallelParam}}
 #'   object specifying how differential testing should be parallelized.
 #' @param verbose logical. Should information on progress be reported?
+#' @param ... Further arguments passed to downstream functions, specifically
+#'   (depending on \code{method}) \code{\link[DESeq2]{DESeq}} or
+#'   \code{\link[edgeR]{glmQLFit}}. Ignored for other methods.
 #'
 #' @return a list containing \itemize{
 #' \item a data.frame with differential testing results,
@@ -83,9 +91,9 @@
 
 pbDS <- function(pb, 
     method=c("edgeR", "DESeq2", "limma-trend", "limma-voom", "DD"),
-    design=NULL, coef=NULL, contrast=NULL, min_cells=10, 
+    design=NULL, coef=NULL, contrast=NULL, min_cells=10, shrinkLFC=FALSE,
     filter=c("both", "genes", "samples", "none"), treat=FALSE, 
-    verbose=TRUE, BPPARAM=SerialParam(progressbar=verbose)) {
+    verbose=TRUE, BPPARAM=SerialParam(progressbar=verbose), ...) {
     
     # check validity of input arguments
     args <- as.list(environment())
@@ -122,6 +130,10 @@ pbDS <- function(pb,
         names(cs) <- names(coef) <- cs
     }
     ct <- ifelse(is.null(coef), "contrast", "coef")
+    
+    if(ct=="contrast" && method=="DESeq2" && 
+       (isTRUE(shrinkLFC) || shrinkLFC=="apeglm"))
+      stop("apeglm shrinkage requires the use of the 'coef' interface.")
     
     if (!is.function(method)) {
         fun <- switch(method,
@@ -163,7 +175,8 @@ pbDS <- function(pb,
         args <- list(
             x=y, k=k, design=d, coef=coef, 
             contrast=contrast, ct=ct, cs=cs,
-            treat=treat, nc=n_cells[k, !rmv])
+            treat=treat, nc=n_cells[k, !rmv], shrinkLFC=shrinkLFC,
+            downstream_args=list(...))
         args <- args[intersect(names(args), fun_args)]
         suppressWarnings(do.call(fun, args))
     })

--- a/R/utils-pbDS.R
+++ b/R/utils-pbDS.R
@@ -72,7 +72,7 @@
     y <- suppressMessages(DGEList(y, 
         group = x$group_id[colnames(y)], 
         remove.zeros = TRUE))
-    y <- normLibSizes(y)
+    y <- normLibSizes(y, method="TMMwsp")
     y <- estimateDisp(y, design)
     fit <- do.call(glmQLFit, c(list(y=y, design=design), downstream_args))
     # treat: test for DE relative to logFC threshold

--- a/R/utils-pbDS.R
+++ b/R/utils-pbDS.R
@@ -61,19 +61,20 @@
 }
 
 #' @importFrom dplyr rename
-#' @importFrom edgeR normLibSizes DGEList estimateDisp
-#'   filterByExpr glmQLFit glmQLFTest glmTreat topTags
+#' @importFrom edgeR normLibSizes DGEList estimateDisp filterByExpr glmQLFit 
+#' @importFrom edgeR glmQLFTest glmTreat topTags
 #' @importFrom scater isOutlier
 #' @importFrom SummarizedExperiment assay
 #' @importFrom S4Vectors metadata
-.edgeR <- function(x, k, design, coef, contrast, ct, cs, treat) {
+.edgeR <- function(x, k, design, coef, contrast, ct, cs, treat, 
+                   downstream_args=list()){
     y <- assay(x, k)
     y <- suppressMessages(DGEList(y, 
         group = x$group_id[colnames(y)], 
         remove.zeros = TRUE))
     y <- normLibSizes(y)
     y <- estimateDisp(y, design)
-    fit <- glmQLFit(y, design)
+    fit <- do.call(glmQLFit, c(list(y=y, design=design), downstream_args))
     # treat: test for DE relative to logFC threshold
     # else:  genewise NB GLM with quasi-likelihood test
     .fun <- ifelse(treat, glmTreat, glmQLFTest)
@@ -158,20 +159,29 @@
     .limma(x, k, design, coef, contrast, ct, cs, method = "voom", treat)
   
 #' @importFrom SummarizedExperiment assay colData
-.DESeq2 <- function(x, k, design, contrast, ct, cs) {
+.DESeq2 <- function(x, k, design, coef, contrast, ct, cs, shrinkLFC,
+                    downstream_args=list()) {
     if (!requireNamespace("DESeq2", quietly=TRUE))
         stop("Install 'DESeq2' to use this method.")
     cd <- colData(x)
     y <- as.matrix(assay(x, k)); mode(y) <- "integer"
     y <- DESeq2::DESeqDataSetFromMatrix(y, cd, design)
-    y <- suppressMessages(DESeq2::DESeq(y))
+    args <- c(list(object=y), downstream_args)
+    y <- suppressMessages(do.call(DESeq2::DESeq, args))
+    if(isTRUE(shrinkLFC)) shrinkLFC <- "apeglm"
     tbl <- lapply(cs, function(c) {
-        tbl <- DESeq2::results(y, contrast[, c])
+        if(isFALSE(shrinkLFC)){
+          tbl <- DESeq2::results(y, contrast[, c])
+        }else{
+          tbl <- suppressMessages(
+            DESeq2::lfcShrink(y, coef=coef[[c]], type=shrinkLFC) )
+        }
         tbl <- .res_df(tbl, k, ct, c)
         old <- c("log2FoldChange", "pvalue", "padj")
         new <- c("logFC", "p_val", "p_adj.loc")
         idx <- match(old, names(tbl))
-        names(tbl)[idx] <- new; tbl
+        names(tbl)[idx] <- new
+        tbl
     })
     list(table = tbl, data = y)
 }

--- a/R/validity-checks.R
+++ b/R/validity-checks.R
@@ -160,6 +160,7 @@
         is.numeric(u$min_cells), length(u$min_cells) == 1,
         is.logical(u$verbose), length(u$verbose) == 1,
         is.logical(u$treat), length(u$treat) == 1)
+    stopifnot(length(u$shrinkLFC)==1)
 }
 
 .check_args_mmDS <- function(u) {

--- a/man/pbDS.Rd
+++ b/man/pbDS.Rd
@@ -12,10 +12,12 @@ pbDS(
   coef = NULL,
   contrast = NULL,
   min_cells = 10,
+  shrinkLFC = FALSE,
   filter = c("both", "genes", "samples", "none"),
   treat = FALSE,
   verbose = TRUE,
-  BPPARAM = SerialParam(progressbar = verbose)
+  BPPARAM = SerialParam(progressbar = verbose),
+  ...
 )
 
 pbDD(
@@ -35,7 +37,7 @@ containing pseudobulks as returned by \code{\link{aggregateData}}.}
 
 \item{method}{a character string.}
 
-\item{design}{For methods \code{"edegR"} and \code{"limma"}, a design matrix 
+\item{design}{For methods \code{"edgeR"} and \code{"limma"}, a design matrix 
 with row & column names(!) created with \code{\link[stats]{model.matrix}}; 
 For \code{"DESeq2"}, a formula with variables in \code{colData(pb)}.
 Defaults to \code{~ group_id} or the corresponding \code{model.matrix}.}
@@ -51,6 +53,12 @@ created with \code{\link[limma]{makeContrasts}}.}
 \item{min_cells}{a numeric. Specifies the minimum number of cells in a given 
 cluster-sample required to consider the sample for differential testing.}
 
+\item{shrinkLFC}{Whether/how to shrink logFCs in DESeq2 analysis. Either 
+FALSE (default, no shrinkage), TRUE (uses \code{\link[DESeq2]{lfcShrink}} 
+with default method, which reguires the \code{apeglm} package), or a 
+character argument indicating the shrinkage method, passed to 
+\code{\link[DESeq2]{lfcShrink}}. Ignored for other methods.}
+
 \item{filter}{character string specifying whether
 to filter on genes, samples, both or neither.}
 
@@ -64,6 +72,10 @@ Only applicable for methods \code{"limma-x"}
 
 \item{BPPARAM}{a \code{\link[BiocParallel]{BiocParallelParam}}
 object specifying how differential testing should be parallelized.}
+
+\item{...}{Further arguments passed to downstream functions, specifically
+(depending on \code{method}) \code{\link[DESeq2]{DESeq}} or
+\code{\link[edgeR]{glmQLFit}}. Ignored for other methods.}
 }
 \value{
 a list containing \itemize{


### PR DESCRIPTION
This is related to #53 :
- it adds `...` arguments to pbDS that are passed to downstream `DESeq2::DESeq` or `edgeR::glmQLFit`
- it adds a `shrinkLFC` argument to use DESeq2 logFC shrinkage (requires apeglm). `edgeR::predFC` wasn't included in the end because this isn't different from what the fitting method does, and just offers the option of changing the pseudocount downstream of the fit. This can now anyway be done because `...` exposes the pseudocount argument.

Additionally, the default edgeR normalization was changed to TMMwsp.